### PR TITLE
Path with multiple verbs

### DIFF
--- a/lib/proxy2openapi.js
+++ b/lib/proxy2openapi.js
@@ -47,7 +47,7 @@ function genopenapi(location, answers, xmlFile, cb) {
           if (verbArr != null && pathArr != null) {
             var resourcePath = pathArr[1];
             var resourceVerb = verbArr[1].toLowerCase();
-            openapiJson.paths[resourcePath] = {};
+            if (!openapiJson.paths[resourcePath]) openapiJson.paths[resourcePath] = {}
             openapiJson.paths[resourcePath][resourceVerb] = {};
             openapiJson.paths[resourcePath][resourceVerb].operationId = openapiPath.$.name;
             if (openapiPath.Description != null) {


### PR DESCRIPTION
Existing code overrides paths with different verbs e.g. path  "/*/reviews" with GET and POST should generate the following:

```
    "/*/reviews": {
      "post": {
        "operationId": "CreateProductReviews",
        "responses": {
          "200": {
            "description": "successful operation"
          }
        },
        "parameters": []
      },
      "get": {
        "operationId": "GetProductReviews",
        "responses": {
          "200": {
            "description": "successful operation"
          }
        },
        "parameters": []
      }
    }
```
